### PR TITLE
Fix brew command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Upon user request I added a mouse simulator as well. I was very skeptical at fir
 1. Install [brew](https://brew.sh/).
 1. Run:
 
-        $ brew cask install mks
+        $ brew install --cask mks
 
 1. Grant Accessibility permissions (see below).
 


### PR DESCRIPTION
The brew cask command has been updated as of [Homebrew 2.6.0](https://github.com/Homebrew/discussions/discussions/340#discussioncomment-232364).